### PR TITLE
ステップ3 プレイヤーの人数と名前の登録機能を追加

### DIFF
--- a/war.rb
+++ b/war.rb
@@ -7,9 +7,10 @@ class Game
   end
 
   def start_game
+    # プレイヤー数を指定
+    register_player_count
+
     # プレイヤー数だけPlayerインスタンスを作成
-    print 'プレイヤーの人数を入力してください（2〜5）: '
-    @player_count = gets.chomp.to_i
     make_players
 
     # 開始メッセージ
@@ -23,6 +24,18 @@ class Game
 
     # 終了メッセージ
     puts '戦争を終了します。'
+  end
+
+  def register_player_count
+    loop do
+      print 'プレイヤーの人数を入力してください（2〜5）: '
+      input = gets.chomp
+      if input.match?(/\A[2-5]\z/)
+        @player_count = input.to_i
+        break
+      end
+      puts '2～5の数字を入力してください。'
+    end
   end
 
   def make_players

--- a/war.rb
+++ b/war.rb
@@ -6,9 +6,10 @@ class Game
     @deck = deck
   end
 
-  def start_game(player_count: 2)
-    @player_count = player_count
+  def start_game
     # プレイヤー数だけPlayerインスタンスを作成
+    print 'プレイヤーの人数を入力してください（2〜5）: '
+    @player_count = gets.chomp.to_i
     make_players
 
     # 開始メッセージ
@@ -26,7 +27,9 @@ class Game
 
   def make_players
     @player_count.times do |i|
-      @players << Player.new(i + 1)
+      print "プレイヤー#{i + 1}の名前を入力してください: "
+      player_name = gets.chomp
+      @players << Player.new(player_name)
     end
   end
 
@@ -43,6 +46,7 @@ class Game
       break if empty_hand_exists
     end
 
+    add_taken_cards_to_hand
     show_players_hands
     result = calculate_result
     announce_result(result)
@@ -99,14 +103,22 @@ class Game
     end
   end
 
+  # 各プレイヤー場札から取ったカードを手札に加える
+  def add_taken_cards_to_hand
+    @players.each do |player|
+      player.hand += player.taken_cards
+      player.taken_cards.clear
+    end
+  end
+
   # 各Playerの手札を表示する
   def show_players_hands
-    puts @players.map { |p| "#{p.name}の手札の枚数は#{p.hand.size + p.taken_cards.size}枚です。" }.join()
+    puts @players.map { |p| "#{p.name}の手札の枚数は#{p.hand.size}枚です。" }.join()
   end
 
   # Playerインスタンスを手札の枚数によって降順で並べる
   def calculate_result
-    @players.sort { |a, b| b.hand.size + b.taken_cards.size <=> a.hand.size + a.taken_cards.size }
+    @players.sort { |a, b| b.hand.size <=> a.hand.size }
   end
 
   # 最終結果を表示する
@@ -131,8 +143,8 @@ class Player
   attr_reader :name
   attr_accessor :hand, :taken_cards
 
-  def initialize(num)
-    @name = "プレイヤー#{num}"
+  def initialize(name)
+    @name = name
     @hand = []
     @taken_cards = []
   end

--- a/war_test.rb
+++ b/war_test.rb
@@ -5,16 +5,21 @@ require_relative 'war'
 # GameTestでは出力結果に一貫性を持たせるためにデッキのシャッフルはしない
 # Deck.newの第二引数をfalseと指定することでシャッフルを無効
 class GameTest < MiniTest::Test
+  # テスト用デッキとキャプチャーのセットアップ
+  def custom_setup(deck)
+    game = Game.new(deck)
+    output, _stderr = capture_io do
+      game.start_game
+    end
+    output
+  end
+
   # 初期状態ののしデッキ
   # 26回の引き分けで終了
   # デッキの並び順: [2, 3, ..., J, Q, K, A]*4
   def test_start_game_with_test_deck_1
     test_deck = Deck.new(nil, false)
-    game = Game.new(test_deck)
-
-    output = capture_io do
-      game.start_game
-    end.first
+    output = custom_setup(test_deck)
 
     assert_match(/プレイヤー1の手札がなくなりました。/, output)
     assert_match(/プレイヤー2の手札がなくなりました。/, output)
@@ -26,11 +31,7 @@ class GameTest < MiniTest::Test
   # デッキの並び順: [3, 8]
   def test_start_game_with_test_deck_2
     test_deck = Deck.new([Card.new(:ダイヤ, 3), Card.new(:ダイヤ, 8)], false)
-    game = Game.new(test_deck)
-
-    output = capture_io do
-      game.start_game
-    end.first
+    output = custom_setup(test_deck)
 
     assert_match(/プレイヤー2の手札がなくなりました。/, output)
     assert_match(/プレイヤー1の手札の枚数は2枚です。プレイヤー2の手札の枚数は0枚です。/, output)
@@ -41,11 +42,7 @@ class GameTest < MiniTest::Test
   # デッキの並び順: [A, J]
   def test_start_game_with_mini_deck_3
     test_deck = Deck.new([Card.new(:ダイヤ, :A), Card.new(:ダイヤ, :J)], false)
-    game = Game.new(test_deck)
-
-    output = capture_io do
-      game.start_game
-    end.first
+    output = custom_setup(test_deck)
 
     assert_match(/プレイヤー1の手札がなくなりました。/, output)
     assert_match(/プレイヤー1の手札の枚数は0枚です。プレイヤー2の手札の枚数は2枚です。/, output)
@@ -56,11 +53,7 @@ class GameTest < MiniTest::Test
   # デッキの並び順: [Q, 7, Q, 10]
   def test_start_game_with_mini_deck_4
     test_deck = Deck.new([Card.new(:スペード, :Q), Card.new(:ダイヤ, 7), Card.new(:クラブ, :Q), Card.new(:ハート, 10)], false)
-    game = Game.new(test_deck)
-
-    output = capture_io do
-      game.start_game
-    end.first
+    output = custom_setup(test_deck)
 
     assert_match(/プレイヤー2の手札がなくなりました。/, output)
     assert_match(/プレイヤー1の手札の枚数は4枚です。プレイヤー2の手札の枚数は0枚です。/, output)

--- a/war_test.rb
+++ b/war_test.rb
@@ -6,7 +6,8 @@ require_relative 'war'
 # Deck.newの第二引数をfalseと指定することでシャッフルを無効
 class GameTest < MiniTest::Test
   # テスト用デッキとキャプチャーのセットアップ
-  def custom_setup(deck)
+  def custom_setup(deck, input)
+    $stdin = StringIO.new(input)
     game = Game.new(deck)
     output, _stderr = capture_io do
       game.start_game
@@ -14,50 +15,97 @@ class GameTest < MiniTest::Test
     output
   end
 
-  # 初期状態ののしデッキ
-  # 26回の引き分けで終了
   # デッキの並び順: [2, 3, ..., J, Q, K, A]*4
-  def test_start_game_with_test_deck_1
+  # プレイヤー数: 2
+  # 名前: たろう, はなこ
+  # 26回引き分けして終了
+  def test_start_game_with_2_players_without_shuffle
     test_deck = Deck.new(nil, false)
-    output = custom_setup(test_deck)
+    output = custom_setup(test_deck, "2\nたろう\nはなこ\n")
 
-    assert_match(/プレイヤー1の手札がなくなりました。/, output)
-    assert_match(/プレイヤー2の手札がなくなりました。/, output)
-    assert_match(/プレイヤー1の手札の枚数は0枚です。プレイヤー2の手札の枚数は0枚です。/, output)
-    assert_match(/プレイヤー1が1位、プレイヤー2が1位です。/, output)
+    assert_match(/たろうの手札がなくなりました。/, output)
+    assert_match(/はなこの手札がなくなりました。/, output)
+    assert_match(/たろうの手札の枚数は0枚です。はなこの手札の枚数は0枚です。/, output)
+    assert_match(/たろうが1位、はなこが1位です。/, output)
+    $stdin = STDIN
   end
 
-  # プレイヤー1が勝利
+  # デッキの並び順: [2, 3, ..., J, Q, K, A]*4
+  # プレイヤー数: 4
+  # 名前: たろう, じろう, さぶろう, しろう
+  # 13回引き分けして終了
+  def test_start_game_with_4_players_without_shuffle
+    test_deck = Deck.new(nil, false)
+    output = custom_setup(test_deck, "4\nたろう\nじろう\nさぶろう\nしろう\n")
+
+    assert_match(/たろうの手札がなくなりました。/, output)
+    assert_match(/じろうの手札がなくなりました。/, output)
+    assert_match(/さぶろうの手札がなくなりました。/, output)
+    assert_match(/しろうの手札がなくなりました。/, output)
+    assert_match(/たろうの手札の枚数は0枚です。じろうの手札の枚数は0枚です。さぶろうの手札の枚数は0枚です。しろうの手札の枚数は0枚です。/, output)
+    assert_match(/たろうが1位、じろうが1位、さぶろうが1位、しろうが1位です。/, output)
+    $stdin = STDIN
+  end
+
   # デッキの並び順: [3, 8]
-  def test_start_game_with_test_deck_2
+  # プレイヤー数: 2
+  # 名前: John, Bob
+  def test_start_game_with_2_players
     test_deck = Deck.new([Card.new(:ダイヤ, 3), Card.new(:ダイヤ, 8)], false)
-    output = custom_setup(test_deck)
+    output = custom_setup(test_deck, "2\nJohn\nBob\n")
 
-    assert_match(/プレイヤー2の手札がなくなりました。/, output)
-    assert_match(/プレイヤー1の手札の枚数は2枚です。プレイヤー2の手札の枚数は0枚です。/, output)
-    assert_match(/プレイヤー1が1位、プレイヤー2が2位です。/, output)
+    assert_match(/Bobの手札がなくなりました。/, output)
+    assert_match(/Johnの手札の枚数は2枚です。Bobの手札の枚数は0枚です。/, output)
+    assert_match(/Johnが1位、Bobが2位です。/, output)
   end
 
-  # プレイヤー2が勝利
-  # デッキの並び順: [A, J]
-  def test_start_game_with_mini_deck_3
-    test_deck = Deck.new([Card.new(:ダイヤ, :A), Card.new(:ダイヤ, :J)], false)
-    output = custom_setup(test_deck)
+  # デッキの並び順: [A, 4, J]
+  # プレイヤー数: 3
+  # 名前: John, Bob, Mike
+  def test_start_game_with_3_players
+    test_deck = Deck.new([Card.new(:ハート, :A), Card.new(:ダイヤ, 4), Card.new(:クラブ, :J)], false)
+    output = custom_setup(test_deck, "3\nJohn\nBob\nMike\n")
 
-    assert_match(/プレイヤー1の手札がなくなりました。/, output)
-    assert_match(/プレイヤー1の手札の枚数は0枚です。プレイヤー2の手札の枚数は2枚です。/, output)
-    assert_match(/プレイヤー2が1位、プレイヤー1が2位です。/, output)
+    assert_match(/Johnの手札がなくなりました。/, output)
+    assert_match(/Bobの手札がなくなりました。/, output)
+    assert_match(/Johnの手札の枚数は0枚です。Bobの手札の枚数は0枚です。Mikeの手札の枚数は3枚です。/, output)
+    assert_match(/Mikeが1位、Johnが2位、Bobが2位です。/, output)
   end
 
-  # 引き分けしてからプレイヤー1が勝利
-  # デッキの並び順: [Q, 7, Q, 10]
-  def test_start_game_with_mini_deck_4
-    test_deck = Deck.new([Card.new(:スペード, :Q), Card.new(:ダイヤ, 7), Card.new(:クラブ, :Q), Card.new(:ハート, 10)], false)
-    output = custom_setup(test_deck)
+  # デッキの並び順: [A, 4, J, 10, A, 2, K, 8]
+  # プレイヤー数: 4
+  # 名前: John, Bob, Mike, Mary
+  def test_start_game_with_4_players
+    test_deck = Deck.new([Card.new(:ハート, :A), Card.new(:ダイヤ, 4),
+                          Card.new(:クラブ, :J), Card.new(:ハート, 10),
+                          Card.new(:ダイヤ, :A), Card.new(:クラブ, 2),
+                          Card.new(:ダイヤ, :K), Card.new(:クラブ, 8)], false)
+    output = custom_setup(test_deck, "4\nJohn\nBob\nMike\nMary\n")
 
-    assert_match(/プレイヤー2の手札がなくなりました。/, output)
-    assert_match(/プレイヤー1の手札の枚数は4枚です。プレイヤー2の手札の枚数は0枚です。/, output)
-    assert_match(/プレイヤー1が1位、プレイヤー2が2位です。/, output)
+    assert_match(/Mikeが勝ちました。Mikeはカードを8枚もらいました。/, output)
+    assert_match(/Johnの手札がなくなりました。/, output)
+    assert_match(/Bobの手札がなくなりました。/, output)
+    assert_match(/Maryの手札がなくなりました。/, output)
+    assert_match(/Johnの手札の枚数は0枚です。Bobの手札の枚数は0枚です。Mikeの手札の枚数は8枚です。Maryの手札の枚数は0枚です。/, output)
+    assert_match(/Mikeが1位、Johnが2位、Bobが2位、Maryが2位です。/, output)
+  end
+
+  # デッキの並び順: [A, 4, J, 10, A, 2, K, 8]
+  # プレイヤー数: 5
+  # 名前: John, Bob, Mike, Mary, Emma
+  def test_start_game_with_5_players
+    test_deck = Deck.new([Card.new(:ハート, 10), Card.new(:ダイヤ, 4),
+                          Card.new(:クラブ, :J), Card.new(:ハート, :Q),
+                          Card.new(:ダイヤ, 2), Card.new(:クラブ, 3),
+                          Card.new(:ダイヤ, :K), Card.new(:クラブ, 8),
+                          Card.new(:ダイヤ, 6), Card.new(:クラブ, 9)], false)
+    output = custom_setup(test_deck, "5\nJohn\nBob\nMike\nMary\nEmma\n")
+
+    assert_match(/Johnの手札がなくなりました。/, output)
+    assert_match(/Mikeの手札がなくなりました。/, output)
+    assert_match(/Emmaの手札がなくなりました。/, output)
+    assert_match(/Johnの手札の枚数は0枚です。Bobの手札の枚数は5枚です。Mikeの手札の枚数は0枚です。Maryの手札の枚数は5枚です。Emmaの手札の枚数は0枚です。/, output)
+    assert_match(/Bobが1位、Maryが1位、Johnが3位、Mikeが3位、Emmaが3位です。/, output)
   end
 end
 


### PR DESCRIPTION
## 内容
提出QUESTステップ3のPR
- プレイヤーの人数を2〜5人で選択できるようにした。
- プレイヤーごとに名前を設定できるようにした。

## 備考
2~5以外の文字列が入力された場合、正しい入力が行われるまでループ処理を行うようにした。